### PR TITLE
update deploy workflow

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -19,6 +19,9 @@ inputs:
   db-connection-string:
     description: "Connection string for accessing backend database"
     required: true
+  base-ref-sha:
+    description: "Base/reference commit SHA-256"
+    required: false
 runs:
   using: "composite"
   steps:
@@ -39,3 +42,4 @@ runs:
         WORKSPACE: ${{ inputs.workspace }}
         ENVIRONMENT: ${{ inputs.environment }}
         DB_CONNECTION_STRING: ${{ inputs.db-connection-string }}
+        BASE_REF_SHA: ${{ inputs.base-ref-sha }}

--- a/.github/actions/deploy/deploy.sh
+++ b/.github/actions/deploy/deploy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -eo pipefail
 
 echo "GITHUB_EVENT_NAME: $GITHUB_EVENT_NAME"
 echo ""
@@ -7,14 +7,14 @@ echo "============================="
 echo "|   Setting up variables    |"
 echo "============================="
 echo ""
-GITHUB_BASE_REF_SHA=$(cat $GITHUB_EVENT_PATH | jq -r '.pull_request.base.sha')
 if [[ "${GITHUB_EVENT_NAME}" = 'pull_request' ]]; then
+  GITHUB_BASE_REF_SHA=$(cat $GITHUB_EVENT_PATH | jq -r '.pull_request.base.sha')
   git config user.name "github-actions[bot]"
   git config user.email "github-actions[bot]@users.noreply.github.com"
   git tag -f last-base-ref-sha $GITHUB_BASE_REF_SHA
   git push -f origin last-base-ref-sha
 elif [[ "${GITHUB_EVENT_NAME}" = 'workflow_dispatch' ]]; then
-  GITHUB_BASE_REF_SHA=$(git rev-parse last-base-ref-sha)
+  GITHUB_BASE_REF_SHA=${BASE_REF_SHA:-$(git rev-parse last-base-ref-sha)}
 fi
 echo "GITHUB_BASE_REF_SHA: $GITHUB_BASE_REF_SHA"
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,13 +8,13 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: "Environment to deploy to"
+        description: "Target environment"
+        type: environment
         required: true
-        default: "staging"
-        type: choice
-        options:
-          - staging
-          - production
+      base-ref-sha:
+        description: "Base/reference commit SHA-256"
+        required: false
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -91,12 +91,12 @@ jobs:
     timeout-minutes: 60
     permissions:
       id-token: write
-      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.GH_PAT }}
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
       - name: Assume AWS role
@@ -119,3 +119,4 @@ jobs:
           workspace: ${{ vars.TF_WORKSPACE }}
           environment: ${{ inputs.environment || 'staging' }}
           db-connection-string: ${{ secrets.DB_CONNECTION_STRING }}
+          base-ref-sha: ${{ inputs.base-ref-sha }}


### PR DESCRIPTION
- update deploy workflow to use gh_pat instead of github token for checkout step (to allow pushing tag)
- add base-ref-sha optional input for workflow_dispatch trigger type